### PR TITLE
fix(dashboard): corrigir contagem de links ativos; test(auth): ajustar slug de redirecionamento

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -62,9 +62,12 @@ class AuthController extends Controller
     // Logout
     public function logout(Request $request)
     {
-        $request->user()->currentAccessToken()->delete();
+        $request->user()->currentAccessToken()?->delete();
+
+        auth() -> guard('web') -> logout();
+
         return response()->json([
             'message' => 'Logout realizado com sucesso'
-        ]);
+        ], 200);
     }
 }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -4,24 +4,36 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Link;
-use Carbon\Carbon;
 
 class DashboardController extends Controller
 {
     public function index(Request $request)
     {
-        $userId = $request -> user() -> id;
+        $userId = $request->user()->id;
+        $now = now();
 
-        $totalLinks = Link::where('user_id', $userId) ->count();
-        $activeLinks = Link::where('user_id', $userId) -> where('status', 'active') -> count();
-        $expiredLinks = Link::where('user_id', $userId) -> whereNotNull ('expires_at') -> where('expires_at', '<', Carbon::now()) -> count();
-        $totalClicks = Link::where('user_id', $userId)-> sum('click_count');
+        $totalLinks = Link::where('user_id', $userId)->count();
 
-        return response() ->json([
-            'total_links' => $totalLinks,
-            'active_links' => $activeLinks,
+        $activeLinks = Link::where('user_id', $userId)
+            ->where('status', 'active')
+            ->where(function ($q) use ($now) {
+                $q->whereNull('expires_at')
+                  ->orWhere('expires_at', '>', $now);
+            })
+            ->count();
+
+        $expiredLinks = Link::where('user_id', $userId)
+            ->whereNotNull('expires_at')
+            ->where('expires_at', '<=', $now)
+            ->count();
+
+        $totalClicks = Link::where('user_id', $userId)->sum('click_count');
+
+        return response()->json([
+            'total_links'   => $totalLinks,
+            'active_links'  => $activeLinks,
             'expired_links' => $expiredLinks,
-            'total_clicks' => $totalClicks,
+            'total_clicks'  => $totalClicks,
         ]);
     }
 }

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -101,7 +101,8 @@ class AuthTest extends TestCase
             'expires_at' => '2025-12-31 23:59:59'
         ]);
 
-        $slug = $linkResponse -> json('slug');
+        $slug = $linkResponse -> json('link.slug');
+        $this -> assertNotEmpty($slug, 'Slug não retornado pelo store()');
 
         // confere contador
         $this -> assertDatabaseHas('links', [


### PR DESCRIPTION
O que foi feito

Correção da contagem de links ativos no dashboard para desconsiderar links expirados (expires_at <= now).
Ajustei o teste de redirecionamento para ler o slug em link.slug e garantir que não esteja vazio.
**Como validar**

_USE:_ php artisan test --filter=AuthTest _**NO TERMINAL**_

Pontos finais:
GET /api/dashboard deve retornar os links ativos sem contar expirados.
GET /api/s/cfr9lI(slug) deve redirecionar e incrementar o contador de clicks

Evidências

**Testes acontecendo (veja screenshot abaixo).**
<img width="1918" height="1077" alt="test1" src="https://github.com/user-attachments/assets/3f9dcb5f-a7f7-4465-a9e8-c56fd36dc171" />

**REGISTER**
<img width="1911" height="200" alt="test5" src="https://github.com/user-attachments/assets/1abbd87d-c619-4f16-9f27-8f1bebafde68" />

**LOGIN**
<img width="1920" height="1032" alt="test4" src="https://github.com/user-attachments/assets/c25b96aa-31ae-4fd2-8110-5093de6f2949" />


**API LINKS**
<img width="1912" height="1023" alt="test3" src="https://github.com/user-attachments/assets/6d40cab6-c94f-470c-81b9-15809df6765e" />

**REDIRECT 3xx, (usei o comando curl-l)**
<img width="1912" height="1027" alt="test2" src="https://github.com/user-attachments/assets/223fbfba-e47d-4753-8576-de331450c5c1" />
.




Notas

Regras:
Ativos = status = active E (expires_at IS NULL OU expires_at > now)
Expirados = expires_at <= now
Checklist



