### PR TITLE
feat(qrcode): expõe qrcode_url e adiciona testes de QR/redirect

### DIFF
--- a/app/Http/Controllers/LinkController.php
+++ b/app/Http/Controllers/LinkController.php
@@ -5,24 +5,20 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use App\Models\Link;
-use SimpleSoftwareIO\QrCode\Facades\QrCode;
 use Carbon\Carbon;
-
-
-
 
 class LinkController extends Controller
 {
     // criar link curto
     public function store(Request $request)
     {
-            // validação
-        $request ->validate([
+        // validação
+        $request->validate([
             'original_url' => 'required|url',
             'expires_at' => 'nullable|date|after:now',
         ]);
 
-        // gerar slug unico semi-random
+        // gerar slug unico 
         $slug = Str::random(6);
         while (Link::where('slug', $slug)->exists()) {
             $slug = Str::random(6);
@@ -30,43 +26,85 @@ class LinkController extends Controller
 
         // cria link
         $link = Link::create([
-            'user_id' => $request ->user() -> id,
-            'original_url' => $request ->original_url,
+            'user_id' => $request->user()->id,
+            'original_url' => $request->original_url,
             'slug' => $slug,
-            'expires_at' => $request ->expires_at ? Carbon::parse($request ->expires_at) : null,
+            'expires_at' => $request->expires_at ? Carbon::parse($request->expires_at) : null,
             'status' => 'active',
             'click_count' => 0,
         ]);
 
-        // gera qrCode em png ou svg
-        $shortUrl = config('app.url') . '/api/s/' . $slug;
-        $qrCode = QrCode::size(200)->generate($shortUrl);
+        // gera qrcode
+        $shortUrl = url("/api/s/{$slug}");
+        $qrcodeUrl = url("/api/qrcode/{$slug}");
 
-
-        // resposta em formato json
+        // resposta em formato json 
         return response()->json([
-            'link' => $link,
+            'id' => $link->id,
+            'slug' => $link->slug,
+            'original_url' => $link->original_url,
+            'click_count' => $link->click_count,
+            'expires_at' => $link->expires_at,
+            'status' => $link->status,
+            'created_at' => $link->created_at,
+            'updated_at' => $link->updated_at,
             'short_url' => $shortUrl,
-            'qr_code' => $qrCode,
+            'qrcode_url' => $qrcodeUrl,
         ], 201);
-
-            
-
     }
 
-    public function index(\Illuminate\Http\Request $request)
+    public function index(Request $request)
     {
         if (!$request->user()) {
             return response()->json(['message' => 'Unauthenticated (debug)'], 401);
         }
 
-        $user = $request->user();
-
-        $links = \App\Models\Link::where('user_id', $user->id)
+        $links = Link::where('user_id', $request->user()->id)
             ->orderByDesc('created_at')
-            ->get();
+            ->get()
+            ->map(function (Link $link) {
+                return [
+                    'id' => $link->id,
+                    'user_id' => $link->user_id,
+                    'slug' => $link->slug,
+                    'original_url' => $link->original_url,
+                    'click_count' => $link->click_count,
+                    'expires_at' => $link->expires_at,
+                    'status' => $link->status,
+                    'created_at' => $link->created_at,
+                    'updated_at' => $link->updated_at,
+                    'short_url' => url("/api/s/{$link->slug}"),
+                    'qrcode_url' => url("/api/qrcode/{$link->slug}"),
+                ];
+            });
 
         return response()->json(['data' => $links], 200);
     }
 
+    public function show(Request $request, int $id)
+    {
+        if(!$request ->user()) {
+            return response()->json(['message' => 'Unauthenticated'], 401);
+        }
+
+        $link = Link::where('id', $id) ->where('user_id', $request->user()->id)->first();
+
+        if(!$link) {
+            return response()->json(['message' => 'Not found'], 404);
+        }
+
+        return response()->json([
+            'id' => $link->id,
+            'user_id'=>$link->user_id,
+            'slug' => $link->slug,
+            'original_url' => $link->original_url,
+            'click_count' => $link->click_count,
+            'expires_at' => $link->expires_at,
+            'status' => $link->status,
+            'created_at' => $link->created_at,
+            'updated_at' => $link->updated_at,
+            'short_url' => url("/api/s/{$link->slug}"),
+            'qrcode_url' => url("/api/qrcode/{$link->slug}"),
+        ], 200);
+    }
 }

--- a/app/Http/Controllers/RedirectController.php
+++ b/app/Http/Controllers/RedirectController.php
@@ -2,35 +2,25 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
 use App\Models\Link;
 use Carbon\Carbon;
 
 class RedirectController extends Controller
 {
-    public function handle($slug) 
+    public function bySlug(string $slug)
     {
-        // buscar link pelo slug
-        $link = Link::where('slug', $slug) -> first();
+        $link = Link::where('slug', $slug)->first();
 
-        // caso não exista
         if (!$link) {
-            return response() -> json([
-                'error' => 'Link Não Encontrado'
-            ], 404);
+            return response()->json(['message' => 'Not found'], 404);
         }
 
-        // verificar se ta expirado
-        if (!is_null($link ->expires_at) && Carbon::parse($link->expires_at) ->isPast()){
-            return response() -> json([
-                'error' => ' LINK EXPIRADO'
-            ], 410);
+        if (!is_null($link->expires_at) && Carbon::parse($link->expires_at)->isPast()) {
+            return response()->json(['message' => 'Link expired'], 410);
         }
 
-        // incrementar contador de cliques
-        $link -> increment ('click_count');
+        $link->increment('click_count');
 
-        // redireciona para url original
-        return redirect() -> away($link -> original_url);
+        return redirect()->away($link->original_url, 302);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,9 +7,12 @@ use App\Http\Controllers\LinkController;
 use App\Http\Controllers\RedirectController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\MetricsController;
+use App\Http\Controllers\QrCodeController; 
 
 // Rotas públicas ------------------------------
 
+// QR Code público por slug 
+Route::get('/qrcode/{slug}', [QrCodeController::class, 'showBySlug']);
 
 // Teste rápido (opcional)
 Route::get('/ping', function () {
@@ -21,11 +24,9 @@ Route::post('/auth/register', [AuthController::class, 'register']);
 Route::post('/auth/login', [AuthController::class, 'login']);
 
 // Redirecionamento pelo slug
-Route::get('/s/{slug}', [RedirectController::class, 'handle']);
-
+Route::get('/s/{slug}', [\App\Http\Controllers\RedirectController::class, 'bySlug']);
 
 // Rotas protegidas (somente autenticados) -----
-
 Route::middleware('auth:sanctum')->group(function () {
 
     // Auth
@@ -36,7 +37,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/links', [LinkController::class, 'index']);       // listar links do usuário
     Route::get('/links/{id}', [LinkController::class, 'show']);   // detalhes de um link
 
-    // Dashboard (MVC ou API)
+    // Dashboard
     Route::get('/dashboard', [DashboardController::class, 'index']);
 
     // Métricas JSON
@@ -44,5 +45,6 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/metrics/top', [MetricsController::class, 'top']);
     Route::get('/metrics/by-month', [MetricsController::class, 'byMonth']);
 
-
+    // QR Code por ID – apenas o dono do link
+    Route::get('/links/{link}/qrcode', [QrCodeController::class, 'showById']);
 });

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -109,12 +109,9 @@ class AuthTest extends TestCase
             'expires_at' => '2025-12-31 23:59:59'
         ]);
 
-        $slug = $linkResponse -> json('link.slug');
-<<<<<<< HEAD
+        $slug = $linkResponse -> json('slug');
         $this -> assertNotEmpty($slug, 'Slug não retornado pelo store');
-=======
-        $this -> assertNotEmpty($slug, 'Slug não retornado pelo store()');
->>>>>>> main
+
 
         // confere contador
         $this -> assertDatabaseHas('links', [

--- a/tests/Feature/LinkStoreTest.php
+++ b/tests/Feature/LinkStoreTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use App\Models\User;
+
+class LinkStoreTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // dtb in memory somente para teste
+        config([
+            'database.default' => 'sqlite',
+            'database.connections.sqlite' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+            ],
+        ]);
+    }
+
+    public function test_store_returns_qrcode_rl()
+    {
+        $user = User::factory() -> create();
+        $this->actingAs($user, 'sanctum');
+
+        $payload = ['original_url' => 'https://laravel.com'];
+        $res = $this->postJson('/api/links', $payload);
+
+        $res->assertStatus(201);
+        $res->assertJsonStructure(['qrcode_url']);
+        $this->assertStringContainsString('/api/qrcode/', $res->json('qrcode_url'));
+    }
+}

--- a/tests/Feature/LinkTest.php
+++ b/tests/Feature/LinkTest.php
@@ -67,7 +67,7 @@ class LinkTest extends TestCase
         $res = $this -> getJson('/api/links');
 
         $res -> assertStatus(200);
-        $data = $res -> json();
+        $data = $res -> json('data');
 
         $this -> assertIsArray($data);
         $this -> assertCount(2, $data);
@@ -104,7 +104,8 @@ class LinkTest extends TestCase
             'expires_at' => now() -> addDay() -> format('Y-m-d H:i:s'),
         ]) -> assertStatus(201);
 
-        $slug = $create -> json('link.slug');
+        $slug = $create -> json('slug');
+        $this->assertNotEmpty($slug, 'Slug não retornado pelo store');
 
         // contador
         $this -> assertDatabaseHas('links', [

--- a/tests/Feature/QrCodeTest.php
+++ b/tests/Feature/QrCodeTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\foundation\Testing\DatabaseMigrations;
+use App\Models\User;
+use App\Models\Link;
+
+class QrCodeTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config ([
+            'database.default' => 'sqlite',
+            'database.connections.sqlite' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+            ],
+        ]);
+    }
+
+    public function test_public_qrcode_by_slug_returns_png_for_active_link()
+    {
+        $user = User::factory() -> create();
+
+        $link = Link::factory() -> create ([
+            'user_id' => $user->id,
+            'original_url' => 'https://laravel.com',
+            'expires_at' => now() -> addDay(),
+        ]);
+
+        $res = $this -> get("/api/qrcode/{$link->slug}");
+        $res -> assertStatus(200);
+        $res -> assertHeader('Content-Type', 'image/png');
+        $this ->assertNotEmpty($res->getContent());
+    }
+
+    public function test_public_qrcode_by_slug_returns_410_fo_expired_link()
+    {
+        $user = User::factory()->create();
+
+        $link = Link::factory()->create([
+            'user_id' => $user -> id,
+            'original_url' => 'https://example.com',
+            'expires_at' => now() ->subMinute(),
+        ]);
+
+        $this -> get("/api/qrcode/{$link -> slug}") ->assertStatus(410);
+    }
+
+    public function test_owner_only_can_Acess_qrcode_by_id()
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+
+        $link = Link::factory()->create([
+            'user_id' => $owner->id,
+            'original_url' => 'https://google.com',
+            'expires_at' => null,          
+            
+        ]);
+
+        // caso seja autenticado como outro usuário
+        $this->actingAs($other, 'sanctum');
+        $this ->get("/api/links/{$link->id}/qrcode")->assertStatus(404);
+    }
+
+
+    public function test_autheticated_owner_gets_png_by_id()
+    {
+        $owner = User::factory()->create();
+
+        $link = Link::factory()->create([
+            'user_id' => $owner ->id,
+            'original_url'  => 'https://php.net',
+            'expires_at' => null,
+        ]);
+
+        $this->actingAs($owner, 'sanctum');
+        $res = $this->get("/api/links/{$link->id}/qrcode");
+        $res->assertStatus(200);
+        $res->assertHeader('Content-Type', 'image/png');
+        $this->assertNotEmpty($res->getContent());
+
+    }
+
+}


### PR DESCRIPTION
Adiciona do campo qrcode_url nas respostas do LinkController (store, index e show) para facilitar consumo pelo frontend/Insomnia.

Implementado método show no LinkController, retornando 404 quando o link não pertence ao usuário autenticado e incluindo short_url e qrcode_url no payload.

Ajustei o RedirectController para usar o método bySlug no redirecionamento público (/api/s/{slug}), com increment de click_count, 404 para não encontrado e 410 para expirado.

Atualizei a listagem (index) para incluir user_id em cada item.

Corrigido testes de Feature para refletirem o novo payload (slug no corpo raiz do store e data no index).

Adicionado testes de QR Code (público e por ID do link), incluindo verificação de Content-Type image/png e regras de acesso.
Garante consistência das mensagens de erro (“Not found” e “Link expired”) e dos status HTTP (404/410).

Limpeza de cache/rotas recomendada após o deploy (_optimize:clear, route:clear_).




**_imagens do teste realizado e aprovado com 100% de acertos_**

TESTE AUTOMATIZADO
<img width="1920" height="1032" alt="test7" src="https://github.com/user-attachments/assets/88c625d6-fa1d-45ce-a422-43311639f91c" />

TESTE DE REDIRECT
<img width="1920" height="1032" alt="test15" src="https://github.com/user-attachments/assets/51f68227-e9e6-4543-98a7-b08af1278bbd" />

TESTE DE REGISTRO
<img width="1920" height="1032" alt="test8" src="https://github.com/user-attachments/assets/a5ca3448-03df-4922-8cb6-cf1f589f1d91" />

TESTE DE LOGIN
<img width="1920" height="1032" alt="test9" src="https://github.com/user-attachments/assets/2abc9897-5692-49d7-a221-87e7a8687772" />

EVIDENCIA DE QUE O COUNT CONTINUA EM 0
<img width="1920" height="1032" alt="test17" src="https://github.com/user-attachments/assets/ffd6c401-1a0e-4245-b213-238fceb40e21" />

TESTE DE LINK EXPIRADO
<img width="1920" height="1032" alt="test16" src="https://github.com/user-attachments/assets/dff74075-fc54-409f-b6c5-11beff889a68" />


TESTE DO QRCODE PUBLICO NO NAVEGADOR
<img width="1920" height="1032" alt="test13" src="https://github.com/user-attachments/assets/8179e7e9-0a1e-45fa-b98b-ed695041835f" />


TESTE LISTANDO E MOSTRANDO DETALHES PT/1
<img width="1920" height="1032" alt="test11" src="https://github.com/user-attachments/assets/6b9b42af-adb2-4497-ac41-fac0b6e4221a" />


TESTE CRIANDO LINK COM QRCODE
<img width="1920" height="1032" alt="test10" src="https://github.com/user-attachments/assets/8d221491-58ef-419b-907d-8f5a56ffa8a0" />





### **_Notas:_**

**Requer a extensão Imagick habilitada no PHP para geração de QR em PNG.**
**Rotas principais: POST /api/links, GET /api/links, GET /api/links/{id}, GET /api/s/{slug}, GET /api/qrcode/{slug}, GET /api/links/{id}/qrcode.**


### **_Como testar:_**
POST /api/auth/register e /api/auth/login para obter token.
POST /api/links com Authorization: Bearer {token}. Verificar short_url e qrcode_url na resposta.
GET {qrcode_url} deve retornar image/png (200).
GET /api/s/{slug} deve redirecionar (302) para original_url e incrementar click_count.
Criar link expirado (expires_at no passado) e acessar /api/s/{slug} deve retornar 410.
GET /api/links/{id}/qrcode autenticado como dono retorna image/png; como outro usuário retorna 404.
