### PR TITLE
feat(auth): implementar logout com Sanctum e padronizar rotas /api/au…

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -60,22 +60,21 @@ class AuthController extends Controller
     }
 
     // Logout
-    public function logout(\Illuminate\Http\Request $request)
+    public function logout(Request $request)
     {
-<<<<<<< HEAD
-        if ($request->user() && $request->user()->currentAccessToken()) {
-            $request->user()->currentAccessToken()->delete();
+        try {
+            $user = $request->user();
+
+            // Revoga TODOS os tokens do usuário
+            $user?->tokens()->delete();
+
+            // Se preferir manter apenas o atual, comente a linha acima e use:
+            // $request->user()?->currentAccessToken()?->delete();
+
+            return response()->json(['message' => 'Logged out'], 200);
+        } catch (\Throwable $e) {
+            return response()->json(['message' => 'Logout failed'], 500);
         }
-
-        return response()->json(['message' => 'Logged out'], 200);
-=======
-        $request->user()->currentAccessToken()?->delete();
-
-        auth() -> guard('web') -> logout();
-
-        return response()->json([
-            'message' => 'Logout realizado com sucesso'
-        ], 200);
->>>>>>> main
     }
+
 }


### PR DESCRIPTION
**_### TESTES REALIZADOS_**


**_TESTE NO INSOMNIA REGISTRANDO USUARIO_**
<img width="1920" height="1032" alt="Captura de tela 2025-08-20 165005" src="https://github.com/user-attachments/assets/95c2ebf1-df2e-4807-a6a4-e28784951be5" />


**_TESTE NO INSOMNIA LOGANDO NO USUARIO CRIADO_**
<img width="1920" height="1032" alt="Captura de tela 2025-08-20 165122" src="https://github.com/user-attachments/assets/aba4b51d-d875-458e-9641-19bbac42147d" />

**_TESTE MOSTRANDO LINKS DO USUARIO_**
<img width="1920" height="1032" alt="Captura de tela 2025-08-20 163602" src="https://github.com/user-attachments/assets/7d4712ac-a394-4b65-9dc1-1d80f8055529" />

**_TESTE LOGOUT_**
<img width="1920" height="1032" alt="Captura de tela 2025-08-20 163756" src="https://github.com/user-attachments/assets/7f88bae3-7449-478c-9971-da85321cbd30" />


**_TESTE DEMONSTRANDO QUE DE FATO O TOKEN FOI APAGADO_**
<img width="1920" height="1032" alt="test18" src="https://github.com/user-attachments/assets/cc0657d0-7772-495a-ad1e-394391de1c15" />

### **_TESTE NO PHP ARTISAN_**
<img width="1920" height="1032" alt="Captura de tela 2025-08-20 165718" src="https://github.com/user-attachments/assets/cfa9e9e8-39dd-4af0-b506-dfbc9dc7aa30" />




### **_Descrição_**

Implementei endpoint POST /api/auth/logout protegido por Sanctum.
Revogação de tokens do usuário e resposta padronizada.
Padronizado as rotas de registro/login/logout em /api/auth/*.
Evidências no Insomnia acima acesso 200 com token, logout 200, acesso com mesmo token retorna 401.


_**### Como testar**_

POST /api/auth/login → copiar token.
GET /api/links com Authorization: Bearer → 200.
POST /api/auth/logout → 200 {"message":"Logged out"}.
GET /api/links com o mesmo token → 401.


### **_Checklist_**

 ✓ Rotas /api/auth/register, /api/auth/login, /api/auth/logout ativas.
 ✓ Logout revoga tokens e retorna 200.
 ✓ Evidências anexadas (Insomnia).
 ✓ php artisan test executado com sucesso.
