### PR TITLE
Dashboard: métricas consolidadas no endpoint /api/dashboard

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -12,46 +12,31 @@ class DashboardController extends Controller
         $userId = $request->user()->id;
         $now = now();
 
-<<<<<<< HEAD
-        $totalLinks = \App\Models\Link::where('user_id', $userId)->count();
-
-        $activeLinks = \App\Models\Link::where('user_id', $userId)
-            ->where('status', 'active')
-            ->where(function ($q) use ($now) {
-                $q->whereNull('expires_at')
-                ->orWhere('expires_at', '>', $now);
-            })
-            ->count();
-
-        $expiredLinks = \App\Models\Link::where('user_id', $userId)
-=======
+        // totais por usuário
         $totalLinks = Link::where('user_id', $userId)->count();
 
+        // ativo = não expirado
         $activeLinks = Link::where('user_id', $userId)
-            ->where('status', 'active')
             ->where(function ($q) use ($now) {
                 $q->whereNull('expires_at')
                   ->orWhere('expires_at', '>', $now);
             })
             ->count();
 
+        // expirado = expires_at passado
         $expiredLinks = Link::where('user_id', $userId)
->>>>>>> main
             ->whereNotNull('expires_at')
             ->where('expires_at', '<=', $now)
             ->count();
 
-<<<<<<< HEAD
-        $totalClicks = \App\Models\Link::where('user_id', $userId)->sum('click_count');
-=======
+        // soma dos cliques
         $totalClicks = Link::where('user_id', $userId)->sum('click_count');
->>>>>>> main
 
         return response()->json([
             'total_links'   => $totalLinks,
             'active_links'  => $activeLinks,
             'expired_links' => $expiredLinks,
             'total_clicks'  => $totalClicks,
-        ]);
+        ], 200);
     }
 }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
 use App\Models\Link;
 
 class DashboardController extends Controller
@@ -10,12 +12,13 @@ class DashboardController extends Controller
     public function index(Request $request)
     {
         $userId = $request->user()->id;
-        $now = now();
+        $now = Carbon::now();
 
-        // totais por usuário
+        // Totais
         $totalLinks = Link::where('user_id', $userId)->count();
+        $totalClicks = (int) Link::where('user_id', $userId)->sum('click_count');
 
-        // ativo = não expirado
+        // Por status 
         $activeLinks = Link::where('user_id', $userId)
             ->where(function ($q) use ($now) {
                 $q->whereNull('expires_at')
@@ -23,20 +26,65 @@ class DashboardController extends Controller
             })
             ->count();
 
-        // expirado = expires_at passado
         $expiredLinks = Link::where('user_id', $userId)
             ->whereNotNull('expires_at')
             ->where('expires_at', '<=', $now)
             ->count();
 
-        // soma dos cliques
-        $totalClicks = Link::where('user_id', $userId)->sum('click_count');
+        // Se você usa um campo 'status' no banco além da regra de expiração
+        $inactiveLinks = Link::where('user_id', $userId)
+            ->where('status', 'inactive')
+            ->count();
+
+        // Últimos 7 dias: links criados por dia
+        $start = Carbon::now()->subDays(6)->startOfDay();
+        $end = Carbon::now()->endOfDay();
+
+        $linksPerDayRaw = Link::where('user_id', $userId)
+            ->whereBetween('created_at', [$start, $end])
+            ->select(DB::raw('DATE(created_at) as d'), DB::raw('COUNT(*) as c'))
+            ->groupBy('d')
+            ->orderBy('d')
+            ->pluck('c', 'd')
+            ->all();
+
+        $linksByDay = [];
+        for ($i = 0; $i < 7; $i++) {
+            $day = $start->copy()->addDays($i)->toDateString();
+            $linksByDay[] = [
+                'date' => $day,
+                'count' => (int)($linksPerDayRaw[$day] ?? 0),
+            ];
+        }
+
+        // Últimos 7 dias: clicks_by_day 
+        $clicksByDay = [];
+        for ($i = 0; $i < 7; $i++) {
+            $day = $start->copy()->addDays($i)->toDateString();
+            $clicksByDay[] = ['date' => $day, 'count' => 0];
+        }
+
+        // Top 5 links por click_count
+        $topLinks = Link::where('user_id', $userId)
+            ->orderByDesc('click_count')
+            ->limit(5)
+            ->get(['id', 'slug', 'original_url', 'click_count']);
 
         return response()->json([
-            'total_links'   => $totalLinks,
-            'active_links'  => $activeLinks,
-            'expired_links' => $expiredLinks,
-            'total_clicks'  => $totalClicks,
+            'totals' => [
+                'total_links' => $totalLinks,
+                'total_clicks' => $totalClicks,
+            ],
+            'by_status' => [
+                'active' => $activeLinks,
+                'expired' => $expiredLinks,
+                'inactive' => $inactiveLinks,
+            ],
+            'last7_days' => [
+                'links_by_day' => $linksByDay,
+                'clicks_by_day' => $clicksByDay,
+            ],
+            'top_links' => $topLinks,
         ], 200);
     }
 }

--- a/app/Http/Controllers/QrCodeController.php
+++ b/app/Http/Controllers/QrCodeController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Link;
+use SimpleSoftwareIO\QrCode\Facades\QrCode;
+
+class QrCodeController extends Controller
+{
+    public function showById(Request $request, Link $link)
+    {
+        if (!$request->user() || $link->user_id !== $request->user()->id) {
+            return response()->json(['message' => 'Not found'], 404);
+        }
+
+        if ($this->isExpired($link)) {
+            return response()->json(['message' => 'Link expired'], 410);
+        }
+
+        $shortUrl = url("/api/s/{$link->slug}");
+        $png = $this->makeQrPng($shortUrl, 300);
+
+        return response($png, 200)->header('Content-Type', 'image/png');
+    }
+
+    public function showBySlug(string $slug)
+    {
+        $link = Link::where('slug', $slug)->first();
+        if (!$link) {
+            return response()->json(['message' => 'Not found'], 404);
+        }
+
+        if ($this->isExpired($link)) {
+            return response()->json(['message' => 'Link expired'], 410);
+        }
+
+        $shortUrl = url("/api/s/{$link->slug}");
+        $png = $this->makeQrPng($shortUrl, 300);
+
+        return response($png, 200)->header('Content-Type', 'image/png');
+    }
+
+    private function isExpired(Link $link): bool
+    {
+        return $link->expires_at && now()->greaterThan($link->expires_at);
+    }
+
+    private function makeQrPng(string $text, int $size = 300): string
+    {
+        return QrCode::format('png')
+            ->size($size)
+            ->margin(1)
+            ->generate($text);
+    }
+}

--- a/app/Models/Link.php
+++ b/app/Models/Link.php
@@ -17,4 +17,10 @@ class Link extends Model
         'expires_at',
         'user_id',
     ];
+
+    protected $casts = [
+        'expires_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "laravel/framework": "^12.0",
         "laravel/sanctum": "^4.2",
         "laravel/tinker": "^2.10.1",
-        "simplesoftwareio/simple-qrcode": "^4.2"
+        "simplesoftwareio/simple-qrcode": "*"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4d0f8fa43aae417fd95b5528a1cdd7d0",
+    "content-hash": "8b2fbec6a2591b187f01f8c3bc55e7ab",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
o PR implementa e consolida o endpoint GET /api/dashboard, que retorna um painel unificado de métricas para o usuário autenticado. O objetivo é fornecer uma visão rápida do desempenho dos links, com totais, distribuição por status, séries temporais dos últimos 7 dias e ranking dos links mais acessados.

### **_O que foi feito_**

✓ Implementação do DashboardController@index com o contrato de resposta padronizado:
✓ totals: total_links e total_clicks do usuário autenticado.
✓ by_status: contagem de links active, expired e inactive.
✓ active: links sem expiração (expires_at nulo) ou com expires_at no futuro.
✓ expired: links com expires_at no passado.
✓ inactive: links com status = 'inactive'.
✓ last7_days:
✓ links_by_day: contagem de links criados por dia, cobrindo hoje-6 até hoje, com dias zerados preenchidos.
✓ clicks_by_day: por enquanto retorna zeros (sem tabela de visitas). Pode ser expandido quando a tabela de visitas estiver em uso.
✓ top_links: top 5 links do usuário, ordenados por click_count desc (campos id, slug, original_url, click_count).
✓ Padronização de casts de datas no Model Link (opcional, se aplicável):
✓ expires_at, created_at, updated_at como datetime para consistência no JSON.
✓ Limpeza de cache de configuração/rotas recomendada pós-deploy: php artisan optimize:clear.
Contrato de resposta
### **_Exemplo de retorno de GET /api/dashboard:_**
{
"totals": {
"total_links": 12,
"total_clicks": 87
},
"by_status": {
"active": 8,
"expired": 3,
"inactive": 1
},
"last7_days": {
"links_by_day": [
{ "date": "2025-08-14", "count": 2 },
{ "date": "2025-08-15", "count": 0 },
{ "date": "2025-08-16", "count": 1 },
{ "date": "2025-08-17", "count": 3 },
{ "date": "2025-08-18", "count": 0 },
{ "date": "2025-08-19", "count": 4 },
{ "date": "2025-08-20", "count": 2 }
],
"clicks_by_day": [
{ "date": "2025-08-14", "count": 0 },
{ "date": "2025-08-15", "count": 0 },
{ "date": "2025-08-16", "count": 0 },
{ "date": "2025-08-17", "count": 0 },
{ "date": "2025-08-18", "count": 0 },
{ "date": "2025-08-19", "count": 0 },
{ "date": "2025-08-20", "count": 0 }
]
},
"top_links": [
{ "id": 42, "slug": "aBc123", "original_url": "https://exemplo.com/", "click_count": 21 },
{ "id": 17, "slug": "xYz789", "original_url": "https://site.com/", "click_count": 18 }
]
}

### **_Decisões de implementação_**

Status active/expired calculado por expires_at, independentemente do campo status, garantindo uma visão fiel à regra de expiração.
clicks_by_day permanece zerado por enquanto para evitar contagem artificial; será atualizado quando a entidade de visitas (visits) estiver integrada ao redirecionamento.
Top links limitado a 5 itens para uso direto em cards ou tabelas no frontend.


### **_Evidências_**

**_TESTE DA AREA DOS TOPS LINKS (INSOMNIA)_**
<img width="1920" height="1032" alt="cap-metric-top-insom" src="https://github.com/user-attachments/assets/cf744d28-d7cb-4575-a869-907f3c2f76a2" />

**_TESTE DO DASHBOARD COMPLETO (INSOMNIA)_**
<img width="1920" height="1032" alt="cap-dash-insom" src="https://github.com/user-attachments/assets/261eeee0-e823-4dd7-989b-acd284b2d4f9" />

**_COMPROVAÇÃO VIA TINKER DE QUE O DASHBOARD ESTÁ CORRETO_**
<img width="1920" height="1032" alt="cap-tinker-numClick" src="https://github.com/user-attachments/assets/428dfb7b-5261-4842-803b-40799a1fe1dd" />



**_### Como testar_**

Autentique-se:
POST /api/auth/login → copie o token.
Dashboard:
GET /api/dashboard com Authorization: Bearer .
Valide que:
totals.total_links = quantidade de links do usuário.
totals.total_clicks = soma de click_count de todos os links do usuário.
by_status.active/expired/inactive batem com as regras descritas.
last7_days.links_by_day tem exatamente 7 itens (de hoje-6 até hoje) e preenche zeros quando aplicável.
top_links tem no máximo 5 registros e está ordenado desc por click_count.

Checklist

 ✓ Endpoint GET /api/dashboard implementado e autenticado (Sanctum).
 ✓ Totais e distribuição por status corretos.
 ✓ Séries dos últimos 7 dias com preenchimento de dias zerados.
 ✓ Top 5 por click_count.
 ✓ Evidências anexadas (prints do Insomnia).
 ✓ php artisan optimize:clear executado localmente