### PR TITLE
Métrics: endpoints auxiliares (summary, top, by-month) com testes e contrato padronizado

### DIFF
--- a/database/factories/LinkFactory.php
+++ b/database/factories/LinkFactory.php
@@ -3,7 +3,10 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+use Carbon\Carbon;
 use App\Models\Link;
+use App\Models\User;
 
 class LinkFactory extends Factory
 {
@@ -12,12 +15,14 @@ class LinkFactory extends Factory
     public function definition(): array
     {
         return [
+            'user_id' => User::factory(),
+            'slug' => Str::random(6),               // evita hífens e caracteres especiais
             'original_url' => $this->faker->url(),
-            'slug' => $this->faker->unique()->slug(2), // slug curto
             'click_count' => 0,
             'status' => 'active',
             'expires_at' => null,
-            'user_id' => \App\Models\User::factory(),
+            'created_at' => Carbon::now(),          // útil para testes que mexem em datas
+            'updated_at' => Carbon::now(),
         ];
     }
 }

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -1,44 +1,150 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Support\Carbon;
 use App\Models\User;
 use App\Models\Link;
 
-#[\PHPUnit\Framework\Attributes\Test]
-public function dashboard_returns_statistics()
+class DashboardTest extends TestCase
 {
-    $user = User::factory()->create();
-    $this->actingAs($user);
+    use DatabaseMigrations;
 
-    // Cria alguns links para o usuário
-    Link::factory()->create([
-        'user_id'      => $user->id,
-        'original_url' => 'https://google.com',
-        'status'       => 'active',
-        'click_count'  => 3,
-    ]);
+    protected User $user;
+    protected string $token;
 
-    Link::factory()->create([
-        'user_id'      => $user->id,
-        'original_url' => 'https://laravel.com',
-        'status'       => 'active',
-        'click_count'  => 2,
-    ]);
+    protected function setUp(): void
+    {
+        parent::setUp();
 
-    Link::factory()->create([
-        'user_id'      => $user->id,
-        'original_url' => 'https://php.net',
-        'status'       => 'active',
-        'expires_at'   => now()->subDay(), // expira ontem
-        'click_count'  => 1,
-    ]);
+        // Cria usuário e token
+        $this->user = User::factory()->create();
+        $res = $this->postJson('/api/auth/login', [
+            'email' => $this->user->email,
+            'password' => 'password', 
+        ]);
+        
+        if ($res->status() !== 200) {
+            $this->token = $this->user->createToken('test')->plainTextToken;
+        } else {
+            $this->token = $res->json('token');
+        }
 
-    // Faz a chamada para o dashboard
-    $response = $this->getJson('/api/dashboard');
+        // Semente de dados para o usuário
+        $now = Carbon::now();
 
-    $response->assertStatus(200);
+        //  ativos (sem expiração ou expiração futura)
+        Link::factory()->create([
+            'user_id' => $this->user->id,
+            'click_count' => 3,
+            'expires_at' => null,
+            'status' => 'active',
+            'created_at' => $now->copy()->subDays(1),
+        ]);
+        Link::factory()->create([
+            'user_id' => $this->user->id,
+            'click_count' => 1,
+            'expires_at' => $now->copy()->addDay(), // futuro
+            'status' => 'active',
+            'created_at' => $now->copy()->subDays(2),
+        ]);
+        Link::factory()->create([
+            'user_id' => $this->user->id,
+            'click_count' => 0,
+            'expires_at' => null,
+            'status' => 'active',
+            'created_at' => $now->copy()->subDays(6),
+        ]);
 
-    $response->assertJson([
-        'total_links'   => 3,
-        'active_links'  => 2,
-        'expired_links' => 1,
-        'total_clicks'  => 6
-    ]);
+        //  expirados
+        Link::factory()->create([
+            'user_id' => $this->user->id,
+            'click_count' => 2,
+            'expires_at' => $now->copy()->subDay(), // passado
+            'status' => 'active',
+            'created_at' => $now->copy()->subDays(3),
+        ]);
+        Link::factory()->create([
+            'user_id' => $this->user->id,
+            'click_count' => 2,
+            'expires_at' => $now->copy()->subDays(5), // passado
+            'status' => 'active',
+            'created_at' => $now->copy()->subDays(5),
+        ]);
+
+        //  inativo (status = inactive)
+        Link::factory()->create([
+            'user_id' => $this->user->id,
+            'click_count' => 0,
+            'expires_at' => null,
+            'status' => 'inactive',
+            'created_at' => $now->copy()->subDays(4),
+        ]);
+
+        // Dados de outro usuário (não devem aparecer)
+        $other = User::factory()->create();
+        Link::factory()->count(2)->create([
+            'user_id' => $other->id,
+            'click_count' => 99,
+            'expires_at' => null,
+            'status' => 'active',
+            'created_at' => $now->copy()->subDays(1),
+        ]);
+    }
+
+    protected function authHeaders(): array
+    {
+        return ['Authorization' => 'Bearer '.$this->token, 'Accept' => 'application/json'];
+    }
+
+    public function test_dashboard_returns_expected_contract_and_values(): void
+    {
+        $res = $this->getJson('/api/dashboard', $this->authHeaders());
+
+        $res->assertStatus(200)
+            ->assertJsonStructure([
+                'totals' => ['total_links', 'total_clicks'],
+                'by_status' => ['active', 'expired', 'inactive'],
+                'last7_days' => [
+                    'links_by_day' => [['date', 'count']],
+                    'clicks_by_day' => [['date', 'count']],
+                ],
+                'top_links' => [['id', 'slug', 'original_url', 'click_count']],
+            ]);
+
+        $json = $res->json();
+
+        // Totais esperados (para o usuário principal)
+        $this->assertSame(6, $json['totals']['total_links']);
+        $this->assertSame(8, $json['totals']['total_clicks']);
+
+        // By status
+        $this->assertSame(3, $json['by_status']['active']);
+        $this->assertSame(2, $json['by_status']['expired']);
+        $this->assertSame(1, $json['by_status']['inactive']);
+
+        // Last 7 days: 7 itens em cada série
+        $this->assertCount(7, $json['last7_days']['links_by_day']);
+        $this->assertCount(7, $json['last7_days']['clicks_by_day']);
+
+        // clicks_by_day são zeros no momento
+        foreach ($json['last7_days']['clicks_by_day'] as $row) {
+            $this->assertSame(0, $row['count']);
+        }
+
+        // Top links: ordenado desc por click_count
+        $top = $json['top_links'];
+        $this->assertLessThanOrEqual(5, count($top));
+        for ($i = 0; $i < count($top) - 1; $i++) {
+            $this->assertGreaterThanOrEqual($top[$i+1]['click_count'], $top[$i]['click_count']);
+        }
+    }
+
+    public function test_dashboard_requires_authentication(): void
+    {
+        $this->getJson('/api/dashboard')->assertStatus(401);
+    }
+    
 }

--- a/tests/Feature/MetricsTest.php
+++ b/tests/Feature/MetricsTest.php
@@ -3,108 +3,141 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Support\Carbon;
 use App\Models\User;
 use App\Models\Link;
 
 class MetricsTest extends TestCase
 {
+    use DatabaseMigrations;
+
+    protected User $user;
+    protected string $token;
+
     protected function setUp(): void
     {
         parent::setUp();
 
-        // Força uso SQLite em memória
-        config([
-            'database.default' => 'sqlite',
-            'database.connections.sqlite.database' => ':memory:',
+        $this->user = User::factory()->create();
+        $login = $this->postJson('/api/auth/login', [
+            'email' => $this->user->email,
+            'password' => 'password',
         ]);
+        $this->token = $login->status() === 200 && $login->json('token')
+            ? $login->json('token')
+            : $this->user->createToken('test')->plainTextToken;
 
-        // Executa migrations antes de cada teste
-        $this->artisan('migrate', ['--force' => true]);
-    }
+        $now = Carbon::now();
 
-    #[\PHPUnit\Framework\Attributes\Test]
-    public function metrics_summary_returns_correct_data()
-    {
-        $user = User::factory()->create();
-        $this->actingAs($user);
-
+        // Dados do usuário principal
+        //  ativos (não expirados)
         Link::factory()->create([
-            'user_id' => $user->id,
-            'click_count' => 5,
-            'status' => 'active',
-        ]);
-
-        Link::factory()->create([
-            'user_id' => $user->id,
+            'user_id' => $this->user->id,
             'click_count' => 3,
-            'expires_at' => now()->subDay(),
+            'expires_at' => null,
             'status' => 'active',
+            'created_at' => $now->copy()->subDays(1),
         ]);
-
-        $response = $this->getJson('/api/metrics/summary');
-
-        $response->assertStatus(200);
-        $response->assertJson([
-            'total_links'   => 2,
-            'active_links'  => 1,
-            'expired_links' => 1,
-            'total_clicks'  => 8
-        ]);
-    }
-
-    #[\PHPUnit\Framework\Attributes\Test]
-    public function metrics_top_returns_links_ordered_by_clicks()
-    {
-        $user = User::factory()->create();
-        $this->actingAs($user);
-
         Link::factory()->create([
-            'user_id' => $user->id,
-            'original_url' => 'https://google.com',
-            'click_count' => 10,
+            'user_id' => $this->user->id,
+            'click_count' => 1,
+            'expires_at' => $now->copy()->addDays(2),
+            'status' => 'active',
+            'created_at' => $now->copy()->subDays(2),
+        ]);
+        Link::factory()->create([
+            'user_id' => $this->user->id,
+            'click_count' => 0,
+            'expires_at' => null,
+            'status' => 'active',
+            'created_at' => $now->copy()->subDays(6),
         ]);
 
+        //  expirados
         Link::factory()->create([
-            'user_id' => $user->id,
-            'original_url' => 'https://laravel.com',
-            'click_count' => 5,
-        ]);
-
-        $response = $this->getJson('/api/metrics/top');
-
-        $response->assertStatus(200);
-        $data = $response->json();
-
-        $this->assertEquals('https://google.com', $data[0]['original_url']);
-        $this->assertEquals('https://laravel.com', $data[1]['original_url']);
-    }
-
-    #[\PHPUnit\Framework\Attributes\Test]
-    public function metrics_by_month_groups_links_and_clicks()
-    {
-        $user = User::factory()->create();
-        $this->actingAs($user);
-
-        Link::factory()->create([
-            'user_id' => $user->id,
-            'click_count' => 3,
-            'created_at' => now()->subMonths(1),
-        ]);
-
-        Link::factory()->create([
-            'user_id' => $user->id,
+            'user_id' => $this->user->id,
             'click_count' => 2,
-            'created_at' => now(),
+            'expires_at' => $now->copy()->subDay(),
+            'status' => 'active',
+            'created_at' => $now->copy()->subDays(3),
+        ]);
+        Link::factory()->create([
+            'user_id' => $this->user->id,
+            'click_count' => 2,
+            'expires_at' => $now->copy()->subDays(5),
+            'status' => 'active',
+            'created_at' => $now->copy()->subDays(5),
         ]);
 
-        $response = $this->getJson('/api/metrics/by-month');
+        //  inativo
+        Link::factory()->create([
+            'user_id' => $this->user->id,
+            'click_count' => 0,
+            'expires_at' => null,
+            'status' => 'inactive',
+            'created_at' => $now->copy()->subDays(4),
+        ]);
 
-        $response->assertStatus(200);
-        $data = $response->json();
+        // Dados de outro usuário 
+        $other = User::factory()->create();
+        Link::factory()->count(2)->create([
+            'user_id' => $other->id,
+            'click_count' => 99,
+            'expires_at' => null,
+            'status' => 'active',
+            'created_at' => $now->copy()->subDays(1),
+        ]);
+    }
 
-        $this->assertNotEmpty($data);
-        $this->assertArrayHasKey('month', $data[0]);
-        $this->assertArrayHasKey('total_links', $data[0]);
-        $this->assertArrayHasKey('total_clicks', $data[0]);
+    protected function headers(): array
+    {
+        return ['Authorization' => 'Bearer ' . $this->token, 'Accept' => 'application/json'];
+    }
+
+    public function test_summary_returns_totals_and_by_status(): void
+    {
+        $res = $this->getJson('/api/metrics/summary', $this->headers());
+
+        $res->assertStatus(200)
+            ->assertJsonStructure([
+                'totals' => ['total_links', 'total_clicks'],
+                'by_status' => ['active', 'expired', 'inactive'],
+            ]);
+
+        $json = $res->json();
+
+        $this->assertSame(6, $json['totals']['total_links']);
+        $this->assertSame(8, $json['totals']['total_clicks']);
+        $this->assertSame(3, $json['by_status']['active']);
+        $this->assertSame(2, $json['by_status']['expired']);
+        $this->assertSame(1, $json['by_status']['inactive']);
+    }
+
+    public function test_top_returns_top5_links(): void
+    {
+        $res = $this->getJson('/api/metrics/top', $this->headers());
+        $res->assertStatus(200)->assertJsonStructure([
+            'top_links' => [['id', 'slug', 'original_url', 'click_count']]
+        ]);
+
+        $top = $res->json('top_links');
+        $this->assertLessThanOrEqual(5, count($top));
+        for ($i = 0; $i < count($top) - 1; $i++) {
+            $this->assertGreaterThanOrEqual($top[$i+1]['click_count'], $top[$i]['click_count']);
+        }
+    }
+
+    public function test_by_month_returns_last_6_months(): void
+    {
+        $res = $this->getJson('/api/metrics/by-month', $this->headers());
+        $res->assertStatus(200)->assertJsonStructure([
+            'months' => [['month', 'links', 'clicks']]
+        ]);
+
+        $months = $res->json('months');
+        $this->assertCount(6, $months);
+        $thisMonth = Carbon::now()->format('Y-m');
+        $this->assertSame($thisMonth, $months[5]['month']);
     }
 }


### PR DESCRIPTION
adicionado e padronizado os endpoints auxiliares de métricas, alinhados ao contrato do dashboard e prontos para consumo pelo frontend. Inclui testes de feature que validam estrutura e cálculos

### **_O que foi implementado_**

GET /api/metrics/summary
**_Retorna:_**
totals: total_links e total_clicks do usuário autenticado.
by_status: contagem mutuamente exclusiva de active, expired e inactive.
**_Regras:_**
active: status != 'inactive' e (expires_at nulo ou futuro).
expired: status != 'inactive' e expires_at no passado.
inactive: status = 'inactive' (independe de expires_at).
GET /api/metrics/top
Retorna top_links (até 5) ordenados por click_count desc com campos id, slug, original_url e click_count.
GET /api/metrics/by-month
Retorna months com os últimos 6 meses contínuos (inclui o mês atual), preenchendo zeros para meses sem links.
Cada item contém: month (YYYY-MM), links e clicks (0 por enquanto).
Compatível com MySQL/MariaDB, PostgreSQL e SQLite.

### **_Teste_**

tests/Feature/MetricsTest.php
Valida contrato e valores de summary (totals e by_status).
Garante ordenação e limite de top_links.
Verifica que by-month retorna exatamente 6 meses e o último é o mês atual.
Usa DatabaseMigrations para isolar o estado do banco.

### **_Rotas_**

Protegidas por auth:sanctum:
GET /api/metrics/summary
GET /api/metrics/top
GET /api/metrics/by-month



Evidências (Insomnia) + artisan test

### **_TEST FEITO NO ARTISAN PELO TERMINAL_**
<img width="1920" height="1032" alt="cap-tes-artisan" src="https://github.com/user-attachments/assets/ad5cc8bf-1604-4ae2-9bef-1a3665b74684" />

### **_TESTE PARA DEMONSTRAR QUE O DASH BOARD É O MESMO DOS DEMAIS TESTES (INSOMNIA)_**
<img width="1920" height="1032" alt="cap-tes-insom-dashboard" src="https://github.com/user-attachments/assets/d61164fb-de33-4ddc-af69-e58264d9aa1f" />

### **_TESTE DO METRICS POR MES (INSOMNIA)_**
<img width="1920" height="1032" alt="cap-tes-insom-metricsByMonth" src="https://github.com/user-attachments/assets/4429e567-b698-4e2f-92dc-da23ac4e72b9" />

### **_TESTE DO SUMARY (INSOMNIA)_**
<img width="1920" height="1032" alt="cap-tes-insom-metricsSummary" src="https://github.com/user-attachments/assets/d5551fa7-1367-4c98-8a8f-d22d21490f4b" />

### **_TESTE DOS TOPS (INSOMNIA)_**
<img width="1920" height="1032" alt="cap-tes-insom-metricsTop" src="https://github.com/user-attachments/assets/91113a80-fe37-4437-b871-e1f70063a3ba" />

### **_OUTRO TESTE DO ARTISAN, ESSE FOI REALIZADO ANTES DO PRIMEIRO_**
<img width="1920" height="1032" alt="cap-test-dashboard" src="https://github.com/user-attachments/assets/6308ea71-4686-4181-9757-997dab1e741a" />






